### PR TITLE
clone from https url

### DIFF
--- a/busy.yaml
+++ b/busy.yaml
@@ -1,4 +1,4 @@
 name: CommonOptions
 extRepositories:
-  - url: git@github.com:SGSSGene/SelfTest.git
-  - url: git@github.com:SGSSGene/Serializer.git
+  - url: https://github.com/SGSSGene/SelfTest.git
+  - url: https://github.com/SGSSGene/Serializer.git


### PR DESCRIPTION
simplify installing for users that just want to use CommonOptions as a tool
